### PR TITLE
Pool will pay 1 miner if configured as such

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# Visual Studio Code
+.vscode/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive" 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 plugins {
     id "org.flywaydb.flyway" version "6.0.0-beta"
     id "distribution"
-    id 'com.palantir.git-version' version '0.12.2'
+    id 'com.palantir.git-version' version '0.12.3'
 }
 
 repositories {
@@ -34,8 +34,9 @@ def dburl =  "jdbc:mariadb://localhost:3306/pooldb"
 def dbusername = "root"
 
 dependencies {
-    implementation 'org.apache.poi:poi-ooxml:4.1.0'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.10'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation 'org.apache.poi:poi-ooxml:5.0.0'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
     implementation 'com.github.burst-apps-team:burstkit4j:b2e653c0d9'
     //implementation 'com.github.jjos2372:burstkit4j:35fbdae491'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'

--- a/dist/pool.properties
+++ b/dist/pool.properties
@@ -73,6 +73,9 @@ minimumMinimumPayout = 2
 # Minimum number of miners paid per transaction, including fee recipient.
 # Pool pays out if every miner has reached minimum payout or if more than
 # this many miners have reached minimum payout
+# Setting to "1" will allow a single transaction payout
+# if there is only 1 miner above their payout threshold, useful if "soloing"
+# on the pool or to get payout for the first miner when starting.
 minPayoutsPerTransaction = 2
 # Number of times to retry making payout transaction if failed
 payoutRetryCount = 3

--- a/src/main/java/burst/pool/db/DefaultCatalog.java
+++ b/src/main/java/burst/pool/db/DefaultCatalog.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Schema;
 import org.jooq.impl.CatalogImpl;

--- a/src/main/java/burst/pool/db/DefaultSchema.java
+++ b/src/main/java/burst/pool/db/DefaultSchema.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Catalog;
 import org.jooq.Table;

--- a/src/main/java/burst/pool/db/Indexes.java
+++ b/src/main/java/burst/pool/db/Indexes.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.Payouts;
 import burst.pool.db.tables.PoolState;
 import burst.pool.db.tables.WonBlocks;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Index;
 import org.jooq.OrderField;

--- a/src/main/java/burst/pool/db/Keys.java
+++ b/src/main/java/burst/pool/db/Keys.java
@@ -19,7 +19,7 @@ import burst.pool.db.tables.records.PayoutsRecord;
 import burst.pool.db.tables.records.PoolStateRecord;
 import burst.pool.db.tables.records.WonBlocksRecord;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Identity;
 import org.jooq.UniqueKey;

--- a/src/main/java/burst/pool/db/Tables.java
+++ b/src/main/java/burst/pool/db/Tables.java
@@ -12,7 +12,8 @@ import burst.pool.db.tables.Payouts;
 import burst.pool.db.tables.PoolState;
 import burst.pool.db.tables.WonBlocks;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
+
 
 
 /**

--- a/src/main/java/burst/pool/db/tables/BestSubmissions.java
+++ b/src/main/java/burst/pool/db/tables/BestSubmissions.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.records.BestSubmissionsRecord;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/FlywaySchemaHistory.java
+++ b/src/main/java/burst/pool/db/tables/FlywaySchemaHistory.java
@@ -13,7 +13,7 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/MinerDeadlines.java
+++ b/src/main/java/burst/pool/db/tables/MinerDeadlines.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.records.MinerDeadlinesRecord;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/Miners.java
+++ b/src/main/java/burst/pool/db/tables/Miners.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.records.MinersRecord;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/Payouts.java
+++ b/src/main/java/burst/pool/db/tables/Payouts.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.records.PayoutsRecord;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/PoolState.java
+++ b/src/main/java/burst/pool/db/tables/PoolState.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.records.PoolStateRecord;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/WonBlocks.java
+++ b/src/main/java/burst/pool/db/tables/WonBlocks.java
@@ -12,7 +12,7 @@ import burst.pool.db.tables.records.WonBlocksRecord;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;

--- a/src/main/java/burst/pool/db/tables/records/BestSubmissionsRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/BestSubmissionsRecord.java
@@ -6,7 +6,7 @@ package burst.pool.db.tables.records;
 
 import burst.pool.db.tables.BestSubmissions;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/db/tables/records/FlywaySchemaHistoryRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/FlywaySchemaHistoryRecord.java
@@ -8,7 +8,7 @@ import burst.pool.db.tables.FlywaySchemaHistory;
 
 import java.sql.Timestamp;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/db/tables/records/MinerDeadlinesRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/MinerDeadlinesRecord.java
@@ -6,7 +6,7 @@ package burst.pool.db.tables.records;
 
 import burst.pool.db.tables.MinerDeadlines;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/db/tables/records/MinersRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/MinersRecord.java
@@ -6,7 +6,7 @@ package burst.pool.db.tables.records;
 
 import burst.pool.db.tables.Miners;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/db/tables/records/PayoutsRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/PayoutsRecord.java
@@ -6,7 +6,7 @@ package burst.pool.db.tables.records;
 
 import burst.pool.db.tables.Payouts;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/db/tables/records/PoolStateRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/PoolStateRecord.java
@@ -6,7 +6,7 @@ package burst.pool.db.tables.records;
 
 import burst.pool.db.tables.PoolState;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/db/tables/records/WonBlocksRecord.java
+++ b/src/main/java/burst/pool/db/tables/records/WonBlocksRecord.java
@@ -6,7 +6,7 @@ package burst.pool.db.tables.records;
 
 import burst.pool.db.tables.WonBlocks;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.*;
 
 import org.jooq.Field;
 import org.jooq.Record1;

--- a/src/main/java/burst/pool/miners/MinerTracker.java
+++ b/src/main/java/burst/pool/miners/MinerTracker.java
@@ -191,6 +191,67 @@ public class MinerTracker {
         if (payableMinersSet.size() < 2 || (payableMinersSet.size() < propertyService.getInt(Props.minPayoutsPerTransaction) && payableMinersSet.size() < storageService.getMinerCount())) {
             payoutSemaphore.release();
             logger.info("Cannot payout. There are {} payable miners, required {}, miner count {}", payableMinersSet.size(), propertyService.getInt(Props.minPayoutsPerTransaction), storageService.getMinerCount());
+           
+            if(payableMinersSet.size() == 1)
+            {
+                logger.info("Found 1 Miner...Maybe i'll try to payout that one.  :) ");
+           
+
+            
+            Payable[] payableMiners = payableMinersSet.size() <= 64 ? payableMinersSet.toArray(new Payable[0]) : Arrays.copyOfRange(payableMinersSet.toArray(new Payable[0]), 0, 64);
+
+            BurstValue transactionFeePaidPerMiner = transactionFee.divide(payableMiners.length);
+            logger.info("TFPM is {}", transactionFeePaidPerMiner.toPlanck());
+            Map<Payable, BurstValue> payees = new HashMap<>(); // Does not have subtracted transaction fee
+            Map<BurstAddress, BurstValue> recipients = new HashMap<>();
+            StringBuilder logMessage = new StringBuilder("Paying out to miners");
+            ByteBuffer transactionAttachment = ByteBuffer.allocate(8 * 2 * payableMiners.length);
+            for (Payable payable : payableMiners) {
+                BurstValue pending = payable.getPending();
+                payees.put(payable, pending);
+                BurstValue actualPayout = pending.subtract(transactionFeePaidPerMiner);
+                recipients.put(payable.getAddress(), actualPayout);
+                transactionAttachment.putLong(payable.getAddress().getBurstID().getSignedLongId());
+                transactionAttachment.putLong(actualPayout.toPlanck().longValue());
+                logMessage.append(", ").append(payable.getAddress().getFullAddress()).append("(").append(actualPayout.toPlanck()).append("/").append(pending.toPlanck()).append(")");
+            }
+            
+            logger.info(logMessage.toString());
+    
+            byte[] publicKey = burstCrypto.getPublicKey(propertyService.getString(Props.passphrase));
+    
+            AtomicReference<BurstID> transactionId = new AtomicReference<>();
+
+            compositeDisposable.add(nodeService.generateTransaction(payableMiners[0].getAddress(), publicKey, 
+                    payableMiners[0].getPending().subtract(transactionFee), transactionFee,
+            1440, null)
+            .retry(propertyService.getInt(Props.payoutRetryCount))
+            .map(response -> burstCrypto.signTransaction(propertyService.getString(Props.passphrase), response))
+            .map(signedBytes -> { // TODO somehow integrate this into burstkit4j
+               byte[] unsigned = new byte[signedBytes.length];
+               byte[] signature = new byte[64];
+               System.arraycopy(signedBytes, 0, unsigned, 0, signedBytes.length);
+               System.arraycopy(signedBytes, 96, signature, 0, 64);
+               for (int i = 96; i < 96 + 64; i++) {
+                   unsigned[i] = 0;
+               }
+               MessageDigest sha256 = burstCrypto.getSha256();
+               byte[] signatureHash = sha256.digest(signature);
+               sha256.update(unsigned);
+               byte[] fullHash = sha256.digest(signatureHash);
+               transactionId.set(burstCrypto.hashToId(fullHash));
+               return signedBytes;
+           })
+           .flatMap(signedBytes -> nodeService.broadcastTransaction(signedBytes)
+                       .retry(propertyService.getInt(Props.payoutRetryCount)))
+           .subscribe(response -> onPaidOut(storageService, transactionId.get(), 
+               payees, publicKey, transactionFee, 1440, transactionAttachment.array()), this::onPayoutError));
+           
+            }
+           
+            logger.info("Made it this far....did it work? ");         
+           
+           
             return;
         }
 
@@ -216,6 +277,10 @@ public class MinerTracker {
         byte[] publicKey = burstCrypto.getPublicKey(propertyService.getString(Props.passphrase));
 
         AtomicReference<BurstID> transactionId = new AtomicReference<>();
+
+
+
+      
 
         compositeDisposable.add(nodeService.generateMultiOutTransaction(publicKey, transactionFee, 1440, recipients)
                 .retry(propertyService.getInt(Props.payoutRetryCount))

--- a/src/main/java/burst/pool/storage/config/Props.java
+++ b/src/main/java/burst/pool/storage/config/Props.java
@@ -35,7 +35,7 @@ public class Props {
 
     public static final Prop<Float> defaultMinimumPayout = new Prop<>("defaultMinimumPayout", 100f); // Must be > 0
     public static final Prop<Float> minimumMinimumPayout = new Prop<>("minimumMinimumPayout", 100f); // Must be > 0
-    public static final Prop<Integer> minPayoutsPerTransaction = new Prop<>("minPayoutsPerTransaction", 10); // Must be 2-64
+    public static final Prop<Integer> minPayoutsPerTransaction = new Prop<>("minPayoutsPerTransaction", 10); // Must be 1-64
     public static final Prop<Integer> payoutRetryCount = new Prop<>("payoutRetryCount", 3);
     public static final Prop<Integer> submitNonceRetryCount = new Prop<>("submitNonceRetryCount", 3);
 
@@ -127,7 +127,7 @@ public class Props {
         }
 
         int minPayoutsPerTransaction = propertyService.getInt(Props.minPayoutsPerTransaction);
-        if (minPayoutsPerTransaction < 2 || minPayoutsPerTransaction > 64) {
+        if (minPayoutsPerTransaction < 1 || minPayoutsPerTransaction > 64) {
             throw new IllegalArgumentException("Illegal minPayoutsPerTransaction: " + minPayoutsPerTransaction + " (Must be 2-64)");
         }
 


### PR DESCRIPTION
I have configured and tested a "1" miner scenario on the pool software.  Not exactly useful real-world but handy for testing out the pool or if someone wants to setup a pool as an intermediate to solo mining.

The main files updated is this one and probably all you need to review/accept if you want to add this functionality:
src/main/java/burst/pool/miners/MinerTracker.java
src/main/java/burst/pool/storage/config/Props.java
dist/pool.properties

All other files that have changes are are a result of my current dev setup.  I wasn't able to get it to build without the changes.

Let me know if you have any other thoughts!