### PR TITLE
Ability to configure a Single Transation Output 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+#Visual Studio Code
+.vscode
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/dist/pool.properties
+++ b/dist/pool.properties
@@ -1,4 +1,4 @@
-# Properties for Babel Pool
+# Properties for Signum Pool
 
 # The port to run the server on
 serverPort = 8000

--- a/dist/pool.properties
+++ b/dist/pool.properties
@@ -73,6 +73,7 @@ minimumMinimumPayout = 2
 # Minimum number of miners paid per transaction, including fee recipient.
 # Pool pays out if every miner has reached minimum payout or if more than
 # this many miners have reached minimum payout
+# Set to 1 will allow single transation payout - useful for testing or "sololing" using a pool.
 minPayoutsPerTransaction = 2
 # Number of times to retry making payout transaction if failed
 payoutRetryCount = 3

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'babel-pool'
+rootProject.name = 'signum-pool'

--- a/src/main/java/burst/pool/miners/MinerTracker.java
+++ b/src/main/java/burst/pool/miners/MinerTracker.java
@@ -198,7 +198,7 @@ public class MinerTracker {
             payableMinersSet.add(poolDonationRecipient);
         }
 
-        if (payableMinersSet.size() < 2 || (payableMinersSet.size() < propertyService.getInt(Props.minPayoutsPerTransaction) && payableMinersSet.size() < storageService.getMinerCount())) {
+        if ((payableMinersSet.size() < 2 && propertyService.getInt(Props.minPayoutsPerTransaction) != 1) || (payableMinersSet.size() < propertyService.getInt(Props.minPayoutsPerTransaction) && payableMinersSet.size() < storageService.getMinerCount())) {
             payoutSemaphore.release();
             logger.info("Cannot payout. There are {} payable miners, required {}, miner count {}", payableMinersSet.size(), propertyService.getInt(Props.minPayoutsPerTransaction), storageService.getMinerCount());
             return;
@@ -227,27 +227,62 @@ public class MinerTracker {
 
         AtomicReference<BurstID> transactionId = new AtomicReference<>();
 
+
+        if(payableMinersSet.size() == 1)
+        {             
+           compositeDisposable.add(nodeService.generateTransaction(payableMiners[0].getAddress(), publicKey, payableMiners[0].getPending().subtract(transactionFee), transactionFee, 1440, null)
+            .retry(propertyService.getInt(Props.payoutRetryCount))
+            .map(response -> burstCrypto.signTransaction(propertyService.getString(Props.passphrase), response))
+            .map(signedBytes -> { // TODO somehow integrate this into burstkit4j
+                byte[] unsigned = new byte[signedBytes.length];
+                byte[] signature = new byte[64];
+                System.arraycopy(signedBytes, 0, unsigned, 0, signedBytes.length);
+                System.arraycopy(signedBytes, 96, signature, 0, 64);
+                for (int i = 96; i < 96 + 64; i++) {
+                    unsigned[i] = 0;
+                }
+                MessageDigest sha256 = burstCrypto.getSha256();
+                byte[] signatureHash = sha256.digest(signature);
+                sha256.update(unsigned);
+                byte[] fullHash = sha256.digest(signatureHash);
+                transactionId.set(burstCrypto.hashToId(fullHash));
+                return signedBytes;
+            })
+            .flatMap(signedBytes -> nodeService.broadcastTransaction(signedBytes)
+                        .retry(propertyService.getInt(Props.payoutRetryCount)))
+            .subscribe(response -> onPaidOut(storageService, transactionId.get(), payees, publicKey, transactionFee, 1440, transactionAttachment.array()), this::onPayoutError));
+
+        }
+        else
+        {
+
+            
         compositeDisposable.add(nodeService.generateMultiOutTransaction(publicKey, transactionFee, 1440, recipients)
-                .retry(propertyService.getInt(Props.payoutRetryCount))
-                .map(response -> burstCrypto.signTransaction(propertyService.getString(Props.passphrase), response))
-                .map(signedBytes -> { // TODO somehow integrate this into burstkit4j
-                    byte[] unsigned = new byte[signedBytes.length];
-                    byte[] signature = new byte[64];
-                    System.arraycopy(signedBytes, 0, unsigned, 0, signedBytes.length);
-                    System.arraycopy(signedBytes, 96, signature, 0, 64);
-                    for (int i = 96; i < 96 + 64; i++) {
-                        unsigned[i] = 0;
-                    }
-                    MessageDigest sha256 = burstCrypto.getSha256();
-                    byte[] signatureHash = sha256.digest(signature);
-                    sha256.update(unsigned);
-                    byte[] fullHash = sha256.digest(signatureHash);
-                    transactionId.set(burstCrypto.hashToId(fullHash));
-                    return signedBytes;
-                })
-                .flatMap(signedBytes -> nodeService.broadcastTransaction(signedBytes)
-                            .retry(propertyService.getInt(Props.payoutRetryCount)))
-                .subscribe(response -> onPaidOut(storageService, transactionId.get(), payees, publicKey, transactionFee, 1440, transactionAttachment.array()), this::onPayoutError));
+        .retry(propertyService.getInt(Props.payoutRetryCount))
+        .map(response -> burstCrypto.signTransaction(propertyService.getString(Props.passphrase), response))
+        .map(signedBytes -> { // TODO somehow integrate this into burstkit4j
+            byte[] unsigned = new byte[signedBytes.length];
+            byte[] signature = new byte[64];
+            System.arraycopy(signedBytes, 0, unsigned, 0, signedBytes.length);
+            System.arraycopy(signedBytes, 96, signature, 0, 64);
+            for (int i = 96; i < 96 + 64; i++) {
+                unsigned[i] = 0;
+            }
+            MessageDigest sha256 = burstCrypto.getSha256();
+            byte[] signatureHash = sha256.digest(signature);
+            sha256.update(unsigned);
+            byte[] fullHash = sha256.digest(signatureHash);
+            transactionId.set(burstCrypto.hashToId(fullHash));
+            return signedBytes;
+        })
+        .flatMap(signedBytes -> nodeService.broadcastTransaction(signedBytes)
+                    .retry(propertyService.getInt(Props.payoutRetryCount)))
+        .subscribe(response -> onPaidOut(storageService, transactionId.get(), payees, publicKey, transactionFee, 1440, transactionAttachment.array()), this::onPayoutError));
+
+        }
+
+
+
     }
 
     private void onPaidOut(StorageService storageService, BurstID transactionID, Map<Payable, BurstValue> paidMiners, byte[] senderPublicKey, BurstValue fee, int deadline, byte[] transactionAttachment) {

--- a/src/main/java/burst/pool/storage/config/Props.java
+++ b/src/main/java/burst/pool/storage/config/Props.java
@@ -37,7 +37,7 @@ public class Props {
 
     public static final Prop<Float> defaultMinimumPayout = new Prop<>("defaultMinimumPayout", 100f); // Must be > 0
     public static final Prop<Float> minimumMinimumPayout = new Prop<>("minimumMinimumPayout", 100f); // Must be > 0
-    public static final Prop<Integer> minPayoutsPerTransaction = new Prop<>("minPayoutsPerTransaction", 10); // Must be 2-64
+    public static final Prop<Integer> minPayoutsPerTransaction = new Prop<>("minPayoutsPerTransaction", 10); // Must be 1-64
     public static final Prop<Integer> payoutRetryCount = new Prop<>("payoutRetryCount", 3);
     public static final Prop<Integer> submitNonceRetryCount = new Prop<>("submitNonceRetryCount", 3);
 
@@ -129,8 +129,8 @@ public class Props {
         }
 
         int minPayoutsPerTransaction = propertyService.getInt(Props.minPayoutsPerTransaction);
-        if (minPayoutsPerTransaction < 2 || minPayoutsPerTransaction > 64) {
-            throw new IllegalArgumentException("Illegal minPayoutsPerTransaction: " + minPayoutsPerTransaction + " (Must be 2-64)");
+        if (minPayoutsPerTransaction < 1 || minPayoutsPerTransaction > 64) {
+            throw new IllegalArgumentException("Illegal minPayoutsPerTransaction: " + minPayoutsPerTransaction + " (Must be 1-64)");
         }
 
     }


### PR DESCRIPTION
I have configured and tested a "1" miner scenario on the pool software. Not exactly useful real-world but handy for testing out the pool or if someone wants to setup a pool as an intermediate to solo mining.


Only issue with this is the code duplication.  Unfortunately I don't know enough about how the unsigned transaction starts nor how the function chaining works alongside this to try and clean it up or disconnect it from the rest of the code.

Side Note: Found a couple naming items related to rebranding